### PR TITLE
Compatibility for ZMQ4

### DIFF
--- a/lib/ZMQ/FFI.pm
+++ b/lib/ZMQ/FFI.pm
@@ -22,10 +22,14 @@ sub new {
     if ($major == 2) {
         require ZMQ::FFI::ZMQ2::Context;
         return ZMQ::FFI::ZMQ2::Context->new(%args);
-    }
-    else {
+    } 
+    elsif ($major == 3) {
         require ZMQ::FFI::ZMQ3::Context;
         return ZMQ::FFI::ZMQ3::Context->new(%args);
+    }
+    else {
+        require ZMQ::FFI::ZMQ4::Context;
+        return ZMQ::FFI::ZMQ4::Context->new(%args);
     }
 };
 

--- a/lib/ZMQ/FFI/ZMQ4/Context.pm
+++ b/lib/ZMQ/FFI/ZMQ4/Context.pm
@@ -1,0 +1,150 @@
+package ZMQ::FFI::ZMQ4::Context;
+{
+  $ZMQ::FFI::ZMQ4::Context::VERSION = '0.07';
+}
+
+use Moo;
+use namespace::autoclean;
+
+use FFI::Raw;
+use Carp;
+
+use ZMQ::FFI::ZMQ4::Socket;
+use ZMQ::FFI::Constants qw(ZMQ_IO_THREADS ZMQ_MAX_SOCKETS);
+
+use Try::Tiny;
+
+with q(ZMQ::FFI::ContextRole);
+
+has '+threads' => (
+    default => 1,
+);
+
+has ffi => (
+    is      => 'ro',
+    lazy    => 1,
+    builder => '_init_ffi',
+);
+
+sub BUILD {
+    my $self = shift;
+
+    try {
+        $self->_ctx( $self->ffi->{zmq_ctx_new}->() );
+        $self->check_null('zmq_ctx_new', $self->_ctx);
+    }
+    catch {
+        $self->_ctx(-1);
+        croak $_;
+    };
+
+    if ( $self->has_threads ) {
+        $self->set(ZMQ_IO_THREADS, $self->_threads);
+    }
+
+    if ( $self->has_max_sockets ) {
+        $self->set(ZMQ_MAX_SOCKETS, $self->_max_sockets);
+    }
+}
+
+sub get {
+    my ($self, $option) = @_;
+
+    my $option_val = $self->ffi->{zmq_ctx_get}->($self->_ctx, $option);
+    $self->check_error('zmq_ctx_get', $option_val);
+
+    return $option_val;
+}
+
+sub set {
+    my ($self, $option, $option_val) = @_;
+
+    $self->check_error(
+        'zmq_ctx_set',
+        $self->ffi->{zmq_ctx_set}->($self->_ctx, $option, $option_val)
+    );
+}
+
+sub socket {
+    my ($self, $type) = @_;
+
+    return ZMQ::FFI::ZMQ4::Socket->new(
+        ctx     => $self,
+        soname  => $self->soname,
+        type    => $type
+    );
+}
+
+sub destroy {
+    my $self = shift;
+
+    $self->check_error(
+        'zmq_ctx_destroy',
+        $self->ffi->{zmq_ctx_destroy}->($self->_ctx)
+    );
+
+    $self->_ctx(-1);
+};
+
+sub _init_ffi {
+    my $self = shift;
+
+    my $ffi    = {};
+    my $soname = $self->soname;
+
+    $ffi->{zmq_ctx_new} = FFI::Raw->new(
+        $soname => 'zmq_ctx_new',
+        FFI::Raw::ptr, # returns ctx ptr
+        # void
+    );
+
+    $ffi->{zmq_ctx_set} = FFI::Raw->new(
+        $soname => 'zmq_ctx_set',
+        FFI::Raw::int, # error code,
+        FFI::Raw::ptr, # ctx
+        FFI::Raw::int, # opt constant
+        FFI::Raw::int  # opt value
+    );
+
+    $ffi->{zmq_ctx_get} = FFI::Raw->new(
+        $soname => 'zmq_ctx_get',
+        FFI::Raw::int, # opt value,
+        FFI::Raw::ptr, # ctx
+        FFI::Raw::int  # opt constant
+    );
+
+    $ffi->{zmq_ctx_destroy} = FFI::Raw->new(
+        $soname => 'zmq_ctx_destroy',
+        FFI::Raw::int, # retval
+        FFI::Raw::ptr  # ctx to destroy
+    );
+
+    return $ffi;
+}
+
+__PACKAGE__->meta->make_immutable();
+
+__END__
+
+=pod
+
+=head1 NAME
+
+ZMQ::FFI::ZMQ3::Context
+
+=head1 VERSION
+
+version 0.07
+
+=head1 AUTHOR
+
+Dylan Cali <calid1984@gmail.com>
+
+=head1 COPYRIGHT AND LICENSE
+
+This software is copyright (c) 2013 by Dylan Cali.
+
+This is free software; you can redistribute it and/or modify it under
+the same terms as the Perl 5 programming language system itself.
+
+=cut

--- a/lib/ZMQ/FFI/ZMQ4/Socket.pm
+++ b/lib/ZMQ/FFI/ZMQ4/Socket.pm
@@ -1,0 +1,121 @@
+package ZMQ::FFI::ZMQ4::Socket;
+{
+  $ZMQ::FFI::ZMQ4::Socket::VERSION = '0.07';
+}
+
+use Moo;
+use namespace::autoclean;
+
+use FFI::Raw;
+
+extends q(ZMQ::FFI::SocketBase);
+
+with q(ZMQ::FFI::SocketRole);
+
+has zmq4_ffi => (
+    is      => 'ro',
+    lazy    => 1,
+    builder => '_init_zmq4_ffi',
+);
+
+sub send {
+    my ($self, $msg, $flags) = @_;
+
+    $flags //= 0;
+
+    $self->check_error(
+        'zmq_send',
+        $self->zmq4_ffi->{zmq_send}->(
+            $self->_socket, $msg, length($msg), $flags
+        )
+    );
+}
+
+sub recv {
+    my ($self, $flags) = @_;
+
+    $flags //= 0;
+
+    my $ffi = $self->ffi;
+
+    my $msg_ptr = FFI::Raw::memptr(40); # large enough to hold zmq_msg_t
+
+    $self->check_error(
+        'zmq_msg_init',
+        $ffi->{zmq_msg_init}->($msg_ptr)
+    );
+
+    my $msg_size =
+        $self->zmq4_ffi->{zmq_msg_recv}->($msg_ptr, $self->_socket, $flags);
+
+    $self->check_error('zmq_msg_recv', $msg_size);
+
+    my $rv;
+    if ($msg_size) {
+        my $data_ptr    = $ffi->{zmq_msg_data}->($msg_ptr);
+        my $content_ptr = FFI::Raw::memptr($msg_size);
+
+        $ffi->{memcpy}->($content_ptr, $data_ptr, $msg_size);
+        $rv = $content_ptr->tostr($msg_size);
+    }
+    else {
+        $rv = '';
+    }
+
+    $ffi->{zmq_msg_close}->($msg_ptr);
+
+    return $rv;
+}
+
+sub _init_zmq4_ffi {
+    my $self = shift;
+
+    my $ffi    = {};
+    my $soname = $self->soname;
+
+    $ffi->{zmq_send} = FFI::Raw->new(
+        $soname => 'zmq_send',
+        FFI::Raw::int, # retval
+        FFI::Raw::ptr, # socket
+        FFI::Raw::str, # message
+        FFI::Raw::int, # length
+        FFI::Raw::int  # flags
+    );
+
+    $ffi->{zmq_msg_recv} = FFI::Raw->new(
+        $soname => 'zmq_msg_recv',
+        FFI::Raw::int, # retval
+        FFI::Raw::ptr, # msg ptr
+        FFI::Raw::ptr, # socket
+        FFI::Raw::int  # flags
+    );
+
+    return $ffi;
+}
+
+__PACKAGE__->meta->make_immutable();
+
+__END__
+
+=pod
+
+=head1 NAME
+
+ZMQ::FFI::ZMQ3::Socket
+
+=head1 VERSION
+
+version 0.07
+
+=head1 AUTHOR
+
+Dylan Cali <calid1984@gmail.com>
+
+=head1 COPYRIGHT AND LICENSE
+
+This software is copyright (c) 2013 by Dylan Cali.
+
+This is free software; you can redistribute it and/or modify it under
+the same terms as the Perl 5 programming language system itself.
+
+=cut

--- a/t/options.t
+++ b/t/options.t
@@ -82,6 +82,9 @@ sub {
     elsif ($major == 3) {
         $opt = ZMQ_MAXMSGSIZE;
     }
+    elsif ($major == 4) {
+        $opt = ZMQ_MAXMSGSIZE;
+    }
     else {
         die "Unsupported zmq version $major";
     }

--- a/t/router-req.t
+++ b/t/router-req.t
@@ -1,0 +1,50 @@
+use strict;
+use warnings;
+
+use Test::More;
+
+use ZMQ::FFI;
+use ZMQ::FFI::Constants qw(ZMQ_ROUTER ZMQ_REQ ZMQ_DONTWAIT);
+
+use Time::HiRes q(usleep);
+
+subtest 'router-req', sub {
+    my $endpoint = "ipc:///tmp/test-zmq-ffi-$$";
+
+    my $ctx = ZMQ::FFI->new();
+
+    my $req = $ctx->socket(ZMQ_REQ);
+    my $rtr = $ctx->socket(ZMQ_ROUTER);
+
+    $req->connect($endpoint);
+    $rtr->bind($endpoint);
+
+    my $message = 'ohhai';
+
+    {
+        $req->send( $message, ZMQ_DONTWAIT );
+
+        until ( $rtr->has_pollin ) {
+
+            # sleep for a 100ms to compensate for slow subscriber problem
+            usleep 100_000;
+        }
+
+        my ( $identifier, $null, $payload ) = $rtr->recv_multipart();
+        is( $null,    '',       "Null is really null" );
+        is( $payload, $message, "Message received" );
+
+        $rtr->send_multipart( [ $identifier, '', '' . reverse($payload) ],
+            ZMQ_DONTWAIT );
+
+        until ( $req->has_pollin ) {
+            usleep 100_000;
+        }
+        diag("Receiving message on REQ");
+        my @result = $req->recv();
+        is( reverse( $result[0] ), $message, "Message received by client" );
+    }
+};
+
+done_testing;
+

--- a/xt/sonames.pl
+++ b/xt/sonames.pl
@@ -18,7 +18,7 @@ sub {
 
     ok
         join('.', zmq_version('libzmq.so.3'))
-        =~ m/^3(\.\d+){2}$/,
+        =~ m/^[34](\.\d+){2}$/,
         'libzmq.so.3 soname gives 3.x version';
 
     throws_ok { zmq_version('libzmq.so.X') }
@@ -41,7 +41,7 @@ sub
 
     ok
         join('.', $ctx_v3->version)
-        =~ m/^3(\.\d+){2}$/,
+        =~ m/^[34](\.\d+){2}$/,
         'libzmq.so.3 soname gives 3.x version';
 
     throws_ok { ZMQ::FFI->new(soname => 'libzmq.so.X') }
@@ -74,7 +74,7 @@ sub
 
     ok
         $s_v3_rep->recv()
-        =~ m/^3(\.\d+){2}$/,
+        =~ m/^[34](\.\d+){2}$/,
         'got zmq 3.x message';
 };
 


### PR DESCRIPTION
Hi calid!

Thank you for providing ZMQ::FFI!

This integrates the libzmq4. In the course of implementing we found out that
FFI::Raw has a bug turning ptr to perl strings if the ptr length is 0 bytes
long.

This can be easily seen in a _standard_ case of zmq when connecting to a
ROUTER socket. Messages to a router always have an identifier, an empty
message part and then the payload ( [ 'ident', '', 'payload' ] ).

I have added a workaround that might even speed up things in the ZMQ4::Socket.
We are also filing a Bug to FFI::Raw.

To prove the case, please run t/router-req.t against ZMQ3/Socket (which still
has the original code).

libzmq.so.4 is not created by zmq4 (read
http://lists.zeromq.org/pipermail/zeromq-dev/2014-January/024718.html for an
explanation) in case you might wonder why the code has not been updated.

Keep up the spirit!

lg,k
