### PR TITLE
Add unbind().

### DIFF
--- a/lib/ZMQ/FFI.pm
+++ b/lib/ZMQ/FFI.pm
@@ -290,6 +290,10 @@ does socket connect on the specified endpoint
 
 does socket bind on the specified endpoint
 
+=head2 unbind($endpoint)
+
+does socket unbind on the specified endpoint. Only available for ZeroMQ 3+.
+
 =head2 get_linger(), set_linger($millis)
 
 get or set the current socket linger period

--- a/lib/ZMQ/FFI/ZMQ3/Socket.pm
+++ b/lib/ZMQ/FFI/ZMQ3/Socket.pm
@@ -3,6 +3,7 @@ package ZMQ::FFI::ZMQ3::Socket;
 use Moo;
 use namespace::autoclean;
 
+use Carp;
 use FFI::Raw;
 
 extends q(ZMQ::FFI::SocketBase);
@@ -56,6 +57,19 @@ sub recv {
     return $content_ptr->tostr($msg_size);
 }
 
+sub unbind {
+    my ($self, $endpoint) = @_;
+
+    unless ($endpoint) {
+        croak 'usage: $socket->unbind($endpoint)';
+    }
+
+    $self->check_error(
+        'zmq_unbind',
+        $self->zmq3_ffi->{zmq_unbind}->($self->_socket, $endpoint)
+    );
+}
+
 sub _init_zmq3_ffi {
     my $self = shift;
 
@@ -77,6 +91,13 @@ sub _init_zmq3_ffi {
         FFI::Raw::ptr, # msg ptr
         FFI::Raw::ptr, # socket
         FFI::Raw::int  # flags
+    );
+
+    $ffi->{zmq_unbind} = FFI::Raw->new(
+        $soname => 'zmq_unbind',
+        FFI::Raw::int,
+        FFI::Raw::ptr,
+        FFI::Raw::str
     );
 
     return $ffi;

--- a/t/pubsub.t
+++ b/t/pubsub.t
@@ -2,6 +2,7 @@ use strict;
 use warnings;
 
 use Test::More;
+use Test::Exception;
 
 use ZMQ::FFI;
 use ZMQ::FFI::Constants qw(ZMQ_PUB ZMQ_SUB ZMQ_DONTWAIT);
@@ -48,6 +49,9 @@ sub {
         my $msg = $s->recv();
         is $msg, 'mytopic ohhai', 'got msg sent to mytopic';
     }
+
+    ok !$p->unbind($endpoint);
+    dies_ok { $p->unbind($endpoint); };
 };
 
 done_testing;


### PR DESCRIPTION
This patch adds a wrapper for the unbind() call, available in ZeroMQ 3+.
