### PR TITLE
fix test to work with old versions of EV

### DIFF
--- a/t/fd.t
+++ b/t/fd.t
@@ -46,6 +46,6 @@ $t = AE::timer 0, .1, sub {
     }
 };
 
-EV::run();
+EV::loop();
 
 done_testing;


### PR DESCRIPTION
I can't tell which version of EV changed this, but somewhere after 3.9
and before 4.15, EV::run() was added. Since I can't tell which version
it was from schmorp's changelogs, fixing it this way seems appropriate.

Alternatively, upgrading the EV requirement to 4.15 appears to fix the problem, which is indeed how I intend to fix the problem for myself.