### PR TITLE
Check for threaded process on FreeBSD

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -15,7 +15,9 @@ delimiter = |
 header = |use FFI::Platypus;
 header = |# Can't currently support unthreaded BSD perls
 header = |# See GH #13
-header = |if ($^O =~ m/bsd/i) {
+header = |if ($^O eq 'freebsd') {
+header = |   (!grep /libthr/, `procstat -v $$`) && exit;
+header = |} elsif ($^O =~ m/bsd/i) {
 header = |   !FFI::Platypus->new(lib => [undef])
 header = |                 ->find_symbol('pthread_self')
 header = |                 && exit;


### PR DESCRIPTION
I believe this should fix #13 on FreeBSD.

on FreeBSD procstat -v will produce a list of the dynamic libs linked to the running process.  Tested this with a threaded perl (installs), an unthreaded perl (stops without creating Makefile) and unthreaded perl with LD_PRELOAD hack (installs).

This will only work on FreeBSD.  As I understand it procstat is part of the core operating system, so it should be safe to assume that it will be available.