### PR TITLE
Specify Import::Into version 1.002005 dependency

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -49,6 +49,7 @@ Moo               = 1.004005
 Class::XSAccessor = 1.18
 Math::BigInt      = 1.997
 FFI::Platypus     = 0.33
+Import::Into      = 1.002005
 
 [Run::BeforeBuild]
 run = perl scripts/gen_zmq_constants.pl
@@ -87,4 +88,4 @@ install_command = cpanm -v .
 ; authordep Pod::Elemental::Transformer::List
 ; authordep Template::Tiny
 ; authordep Path::Class
-
+; authordep FFI::TinyCC


### PR DESCRIPTION
Tests fail with Import::Into version 1.002001. ZMQ::FFI fails to include
constants specified on the `use` line. Version 1.002005 (latest at the
time of this patch) resolves the issue.

Also added an authordep line for FFI::TinyCC which seemed to be necessary to run `dzil listdeps` (or anything other than `dzil authordeps` actually).