### PR TITLE
Socket objects remove themselves from the context object on destruction

### DIFF
--- a/inc/ZMQ2/ContextWrappers.pm
+++ b/inc/ZMQ2/ContextWrappers.pm
@@ -67,6 +67,7 @@ sub socket {
 
         $socket = ZMQ::FFI::[% zmqver %]::Socket->new(
             socket_ptr   => $socket_ptr,
+            context      => $self, # this will become a weak ref
             type         => $type,
             soname       => $self->soname,
         );
@@ -75,7 +76,8 @@ sub socket {
         die $_;
     };
 
-    push @{$self->sockets}, $socket;
+    # add the socket to the socket hash
+    $self->_add_socket($socket);
 
     return $socket;
 }

--- a/inc/ZmqContext.pm.tt
+++ b/inc/ZmqContext.pm.tt
@@ -11,6 +11,7 @@ use ZMQ::FFI::[% zmqver %]::Socket;
 use ZMQ::FFI::[% zmqver %]::Raw;
 use ZMQ::FFI::Custom::Raw;
 use Try::Tiny;
+use Scalar::Util qw(weaken);
 [% lib_imports %]
 use Moo;
 use namespace::clean;
@@ -39,6 +40,16 @@ sub BUILD {
 [%- [%- method -%] -%]
 [% END %]
 
+sub _add_socket {
+    my ($self, $socket) = @_;
+    weaken($self->sockets->{$socket} = $socket);
+}
+
+sub _remove_socket {
+    my ($self, $socket) = @_;
+    delete($self->sockets->{$socket});
+}
+
 sub DEMOLISH {
     my ($self) = @_;
 
@@ -47,7 +58,8 @@ sub DEMOLISH {
     # check defined to guard against
     # undef objects during global destruction
     if (defined $self->sockets) {
-        for my $socket (@{$self->sockets}) {
+        for my $socket_k (keys %{$self->sockets}) {
+            my $socket = $self->_remove_socket($socket_k);
             $socket->close()
                 if defined $socket && $socket->socket_ptr != -1;
         }

--- a/inc/ZmqSocket.pm.tt
+++ b/inc/ZmqSocket.pm.tt
@@ -58,6 +58,9 @@ sub BUILD {
 sub DEMOLISH {
     my ($self) = @_;
 
+    # remove ourselves from the context object so that we dont leak
+    $self->context->_remove_socket($self) if (defined $self->context);
+
     return if $self->socket_ptr == -1;
 
     $self->close();

--- a/lib/ZMQ/FFI/ContextRole.pm
+++ b/lib/ZMQ/FFI/ContextRole.pm
@@ -40,7 +40,7 @@ has max_sockets => (
 has sockets => (
     is        => 'rw',
     lazy      => 1,
-    default   => sub { [] },
+    default   => sub { {} },
 );
 
 requires qw(

--- a/lib/ZMQ/FFI/SocketRole.pm
+++ b/lib/ZMQ/FFI/SocketRole.pm
@@ -25,6 +25,13 @@ has socket_ptr => (
     default => -1,
 );
 
+# a weak reference to the context object
+has context => (
+    is       => 'ro',
+    required => 1,
+    weak_ref => 1,
+);
+
 # message struct to reuse when sending/receiving
 has _zmq_msg_t => (
     is        => 'ro',


### PR DESCRIPTION
For a description see issue https://github.com/calid/zmq-ffi/issues/33#issuecomment-204218791

> With this change, sockets that go out of scope will have their demolish method invoked right away and ultimately get closed. Context objects that go out of scope will continue to do what they did before and demolish all sockets that it owns before cleaning itself up.
> 
> With out the change, socket objects that went out of scope were not demolished until the context object went out of scope.
> 
> So... this will be a slight change in behavior that could be a bad thing, but it feels like the right thing to do.

Let me know if you disagree with this change or if you want it refactored in anyway. 
