### PR TITLE
Perl 5.38.0 deprecates `when` keyword

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,9 @@ jobs:
           - { os: 'ubuntu-latest', perl: "5.20" }
           - { os: 'ubuntu-latest', perl: "5.30" }
           - { os: 'ubuntu-latest', perl: "5.32" }
-          - { os: 'ubuntu-latest', perl: "5.32", perl-threaded: true }
+          - { os: 'ubuntu-latest', perl: "5.34" }
+          - { os: 'ubuntu-latest', perl: "5.36" }
+          - { os: 'ubuntu-latest', perl: "5"    , perl-threaded: true }
     name: Perl ${{ matrix.perl }} on ${{ matrix.os }}, ${{ matrix.alien }}
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Make distribution
         shell: bash
         run: |
@@ -20,7 +20,7 @@ jobs:
                 dzil authordeps --missing | cpanm -n;
                 dzil clean && dzil build --in build-dir"
       - name: Upload artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: dist
           path: ./build-dir
@@ -45,7 +45,7 @@ jobs:
 
     steps:
       - name: Get dist artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: dist
 

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -17,10 +17,12 @@ jobs:
         run: |
           ./docker-run sh -c "
                 dzil authordeps --missing | cpanm -n;
+                cpanm -nq Sys::SigAction; # temporary until release of new test image
                 dzil test"
       - name: docker-test-install
         run: |
           ./docker-run sh -c "
                 dzil authordeps --missing | cpanm -n;
+                cpanm -nq Sys::SigAction; # temporary until release of new test image
                 dzil clean && dzil build;
                 cpanm -v ZMQ-FFI-*.tar.gz"

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: dzil test
         run: |
           ./docker-run sh -c "

--- a/Dockerfile
+++ b/Dockerfile
@@ -79,7 +79,7 @@ RUN apt-get install -y libdist-zilla-perl libterm-ui-perl libanyevent-perl \
 FROM dzil-base as zmq-ffi-base
 COPY . /zmq-ffi/
 RUN cd /zmq-ffi && dzil authordeps --missing | cpanm -v
-RUN cd /zmq-ffi && dzil listdeps --missing | cpanm -v
+RUN cd /zmq-ffi && dzil listdeps --missing | cpanm -v && cpanm -v Sys::SigAction
 RUN apt-get -y purge gcc g++ autoconf automake libtool-bin pkg-config \
         libssl-dev zlib1g-dev uuid-dev \
     && apt -y autoremove \

--- a/inc/ZMQ2/SocketWrappers.pm
+++ b/inc/ZMQ2/SocketWrappers.pm
@@ -290,7 +290,7 @@ sub get {
     my $optval_len;
 
     for ($opt_type) {
-        when (/^(binary|string)$/) {
+        if ($_ =~ /^(binary|string)$/) {
             # ZMQ_IDENTITY uses binary type and can be at most 255 bytes long
             #
             # ZMQ_LAST_ENDPOINT uses string type and expects a buffer large
@@ -331,7 +331,7 @@ sub get {
             }
         }
 
-        when ('int') {
+        elsif ($_ eq 'int') {
             $optval_len = $self->sockopt_sizes->{'int'};
             $self->check_error(
                 'zmq_getsockopt',
@@ -344,7 +344,7 @@ sub get {
             );
         }
 
-        when ('int64_t') {
+        elsif ($_ eq 'int64_t') {
             $optval_len = $self->sockopt_sizes->{'sint64'};
             $self->check_error(
                 'zmq_getsockopt',
@@ -357,7 +357,7 @@ sub get {
             );
         }
 
-        when ('uint64_t') {
+        elsif ($_ eq 'uint64_t') {
             $optval_len = $self->sockopt_sizes->{'uint64'};
             $self->check_error(
                 'zmq_getsockopt',
@@ -370,7 +370,7 @@ sub get {
             );
         }
 
-        default {
+        else {
             croak "unknown type $opt_type";
         }
     }
@@ -390,7 +390,7 @@ sub set {
     [% closed_socket_check %]
 
     for ($opt_type) {
-        when (/^(binary|string)$/) {
+        if ($_ =~ /^(binary|string)$/) {
             my ($optval_ptr, $optval_len) = scalar_to_buffer($optval);
             $self->check_error(
                 'zmq_setsockopt',
@@ -403,7 +403,7 @@ sub set {
             );
         }
 
-        when ('int') {
+        elsif ($_ eq 'int') {
             $self->check_error(
                 'zmq_setsockopt',
                 zmq_setsockopt_int(
@@ -415,7 +415,7 @@ sub set {
             );
         }
 
-        when ('int64_t') {
+        elsif ($_ eq 'int64_t') {
             $self->check_error(
                 'zmq_setsockopt',
                 zmq_setsockopt_int64(
@@ -427,7 +427,7 @@ sub set {
             );
         }
 
-        when ('uint64_t') {
+        elsif ($_ eq 'uint64_t') {
             $self->check_error(
                 'zmq_setsockopt',
                 zmq_setsockopt_uint64(
@@ -439,7 +439,7 @@ sub set {
             );
         }
 
-        default {
+        else {
             croak "unknown type $opt_type";
         }
     }


### PR DESCRIPTION
Fixes <https://github.com/zeromq/perlzmq/issues/51>.

Also some CI / Docker fixes:

- CI: Update Perl matrix up to Perl 5.38: in order to test against Perl 5.38.
- CI: Update actions versions: See <https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/>.
- Install `Sys::SigAction` in test environment image: This will require a new Docker image to be pushed.
